### PR TITLE
Add -w/--wslwindows option

### DIFF
--- a/src/nativeMain/kotlin/Main.kt
+++ b/src/nativeMain/kotlin/Main.kt
@@ -14,6 +14,7 @@ import com.github.ajalt.mordant.rendering.TextStyles.*
 import com.github.ajalt.mordant.terminal.Terminal
 import com.soywiz.kds.iterators.fastForEach
 import com.soywiz.kds.iterators.fastForEachWithIndex
+import com.soywiz.korio.lang.Environment
 import kotlin.test.assertNotNull
 
 val CLILOGO = bold(
@@ -37,6 +38,7 @@ class OperationOptions : OptionGroup(name = "Operation Options", help = Msg.oper
   val keep by option("-k", "--keep", help = Msg.keepOptionHelp).flag(default = false)
   val time by option("-t", "--time", help = Msg.timeOptionHelp).flag(default = false)
   val clean by option("-c", "--clean", help = Msg.cleanOptionHelp).flag(default = false)
+  val wslwindows by option("-w", "--wslwindows", help = Msg.wslWindowsOptionHelp).flag(default = false)
 }
 
 class DevfileCLI : CliktCommand(
@@ -102,6 +104,7 @@ class DevfileCLI : CliktCommand(
         if (operationOptions.quiet) add(OpOptions.QUIET)
         if (operationOptions.keep) add(OpOptions.KEEP)
         if (operationOptions.time) add(OpOptions.TIME)
+        if (operationOptions.wslwindows) add(OpOptions.WSLWINDOWS)
       }
       op.execute(options, operationArguments)
     }

--- a/src/nativeMain/kotlin/Msg.kt
+++ b/src/nativeMain/kotlin/Msg.kt
@@ -1,5 +1,6 @@
 import com.github.ajalt.mordant.rendering.TextColors.*
 
+@ThreadLocal
 object Msg {
 //  val helpText = "Tired of the weird quirks of make? Annoyed of making typos in long chained commands, or getting to them via reverse-i-search?\n" +
 //      "Well, here is a solution that comes as just an executable for each platform and with an extensive help command.\n" +
@@ -16,7 +17,7 @@ object Msg {
 $CLILOGO ```
 Tired of the weird quirks of make? Annoyed of making typos in long chained commands, or getting to them via reverse-i-search?
 Well, here is a solution that comes as just an executable for each platform and with an extensive help command.""" +
-"\nby Sett | ${brightGreen("https://github.com/Sett17/Devfile")}"
+      "\nby Sett | ${brightGreen("https://github.com/Sett17/Devfile")}"
 
   const val operationOptionsHelp = "All of these options can also be used as option letters in the Devfile"
   const val printOptionHelp = "Prints the corresponding script for the operation and execute it"
@@ -24,8 +25,10 @@ Well, here is a solution that comes as just an executable for each platform and 
   const val keepOptionHelp = "Keeps the script file after execution"
   const val timeOptionHelp = "Times the execution of the Operation, and prints it afterwards"
   const val cleanOptionHelp = "Removes all output related to Devfile. To e.g. use it with pipes. Some debug messages will still be printed, when the debug mode is enabled"
+  var wslWindowsOptionHelp = "When running on WSL2, execute the script on the windows host. No effect otherwise. ${gray("Currently only works with windows on C drive and mounted inside WSL2")}"
 
-  const val debugOptionHelp = "Enables output of debug messages for Devfile itself. This has to be its own option (or be the first one in concatenated options), because it is parsed separately. -DD prints even more Information"
+  const val debugOptionHelp =
+    "Enables output of debug messages for Devfile itself. This has to be its own option (or be the first one in concatenated options), because it is parsed separately. -DD prints even more Information"
   const val versionOptionHelp = "Prints the current version and exit"
   const val cleanTmpOptionHelp = "Deletes all .dev files in the platform corresponding tmp directory"
   const val listOptionHelp = "Lists all operations and exit"
@@ -35,5 +38,5 @@ Well, here is a solution that comes as just an executable for each platform and 
 
   const val opsArgumentHelp = "Which operation you want to execute, in the order you want them to execute. The arguments name should be supplied in the same order as defied in the Devfile"
 
-  fun errorNotAnOperation(s: Any) : String = "$s is not an operation! Use 'dev -l' to show all operations"
+  fun errorNotAnOperation(s: Any): String = "$s is not an operation! Use 'dev -l' to show all operations"
 }

--- a/src/nativeMain/kotlin/Operation.kt
+++ b/src/nativeMain/kotlin/Operation.kt
@@ -66,6 +66,7 @@ enum class OpOptions(val option: String) {
   KEEP("k"),
   TIME("t"),
   CLEAN("c"),
+  WSLWINDOWS("w"),
   DUMMY("DUMMY");
 
   fun toStringShort(): String {

--- a/src/nativeMain/kotlin/Specifics.kt
+++ b/src/nativeMain/kotlin/Specifics.kt
@@ -1,43 +1,57 @@
 import com.soywiz.korio.file.VfsFile
+import com.soywiz.korio.file.std.jailedLocalVfs
 import com.soywiz.korio.file.std.tempVfs
 import kotlinx.coroutines.runBlocking
 import platform.posix.system
 
+@ThreadLocal
 object Specifics {
-  private val currentOS = Platform.osFamily
+  private var currentOS: OS = if (Platform.osFamily == OsFamily.LINUX) {
+    if (system("cat /proc/version | grep -q WSL2") == 0) {
+      OS.WSL_LINUX
+    } else OS.LINUX
+  } else if (Platform.osFamily == OsFamily.WINDOWS) {
+    OS.WINDOWS
+  } else {
+    exitError("${Platform.osFamily} is currently not supported by Devfile", 95)
+    OS.UNSUPPORTED
+  }
 
   fun execute(script: String, options: Set<OpOptions>, argumentMap: MutableMap<String, String>) {
     dbgTime("creating and executing file") {
       runBlocking {
 
-        var prefixLines = listOf<String>()
-        var suffixLines = listOf<String>()
-        var howToExec = ""
-        var silence = ""
-        var extension = ""
-
-        when (currentOS) {
-          OsFamily.LINUX   -> {
-            prefixLines = listOf("shopt -s expand_aliases", "source ~/.bash_aliases") + argumentMap.map { "DEV_${it.key.uppercase()}=${it.value}" }
-            howToExec = "/bin/bash"
-            silence = "> /dev/null"
-            extension = ".dev"
-          }
-          OsFamily.WINDOWS -> {
-            prefixLines = listOf("@echo off") + argumentMap.map { "set DEV_${it.key.uppercase()}=${it.value}" }
-            suffixLines = listOf("@echo on")
-            howToExec = ""
-            silence = ">NUL"
-            extension = ".dev.bat"
-          }
-//      OsFamily.MACOSX -> {}
-          else             -> exitError("There is currently no support for executing operations on $currentOS", 38)
+        if (currentOS == OS.WSL_LINUX && OpOptions.WSLWINDOWS in options) {
+          currentOS = OS.WSL_WINDOWS
         }
 
-        VfsFile(tempVfs.vfs, "devfiles/").mkdir()
-        val tmpFile = VfsFile(tempVfs.vfs, "devfiles/${script.hashCode()}${extension}")
-        tmpFile.writeLines(prefixLines + script.lines() + suffixLines)
-        system("$howToExec ${tmpFile.absolutePath} ${if (OpOptions.QUIET in options) silence else ""}")
+        var prefixLines = listOf<String>()
+
+        when (currentOS) {
+          OS.LINUX       -> {
+            prefixLines = listOf("shopt -s expand_aliases", "source ~/.bash_aliases") + argumentMap.map { "DEV_${it.key.uppercase()}=${it.value}" }
+          }
+          OS.WSL_LINUX   -> {
+            prefixLines = listOf("shopt -s expand_aliases", "source ~/.bash_aliases") + argumentMap.map { "DEV_${it.key.uppercase()}=${it.value}" }
+          }
+          OS.WINDOWS     -> {
+            prefixLines = listOf("@echo off") + argumentMap.map { "set DEV_${it.key.uppercase()}=${it.value}" }
+          }
+          OS.WSL_WINDOWS -> {
+            prefixLines = listOf("@echo off") + argumentMap.map { "set DEV_${it.key.uppercase()}=${it.value}" }
+          }
+          else           -> exitError("There is currently no support for executing operations on $currentOS", 38)
+        }
+
+        val tmpVfs = if (OpOptions.WSLWINDOWS in options) {
+          jailedLocalVfs("/mnt/c/Windows/Temp").vfs
+        } else {
+          tempVfs.vfs
+        }
+        VfsFile(tmpVfs, "devfiles/")
+        val tmpFile = VfsFile(tmpVfs, "devfiles/${script.hashCode()}${currentOS.extension}").also { dbg(it.windowsPath) }
+        tmpFile.writeLines(prefixLines + script.lines() + currentOS.suffixLines)
+        system("${currentOS.howToExec} ${tmpFile.windowsPath} ${if (OpOptions.QUIET in options) currentOS.silence else ""}")
         if (OpOptions.KEEP !in options) tmpFile.delete()
       }
     }
@@ -46,15 +60,60 @@ object Specifics {
   fun edit() {
     var howToEdit = ""
     when (currentOS) {
-      OsFamily.LINUX   -> {
+      OS.LINUX       -> {
         howToEdit = "\"\${EDITOR:-vim}\" "
       }
-      OsFamily.WINDOWS -> {
+      OS.WSL_LINUX   -> {
+        howToEdit = "\"\${EDITOR:-vim}\" "
+      }
+      OS.WSL_WINDOWS -> {
+        howToEdit = "\"\${EDITOR:-vim}\" "
+      }
+      OS.WINDOWS     -> {
         howToEdit = "start"
       }
 
-      else             -> exitError("There is currently no support for editing files on $currentOS", 38)
+      else           -> exitError("There is currently no support for editing files on $currentOS", 38)
     }
     system("$howToEdit ${Devfile.devfile.absolutePath}")
   }
+}
+
+enum class OS {
+  LINUX {
+    override val suffixLines = listOf("")
+    override val howToExec = "/bin/bash"
+    override val silence = "> /dev/null"
+    override val extension = ".dev"
+
+  },
+  WINDOWS {
+    override val suffixLines = listOf("@echo on")
+    override val howToExec = ""
+    override val silence = ">NUL"
+    override val extension = ".dev.bat"
+  },
+  WSL_LINUX {
+    override val suffixLines = LINUX.suffixLines
+    override val howToExec = LINUX.howToExec
+    override val silence = LINUX.silence
+    override val extension = LINUX.extension
+  },
+  WSL_WINDOWS {
+    override val suffixLines = WINDOWS.suffixLines
+    override val howToExec = "/mnt/c/Windows/System32/cmd.exe /c"
+    override val silence = LINUX.silence
+    override val extension = WINDOWS.extension
+  },
+  UNSUPPORTED {
+    override val suffixLines = listOf("")
+    override val howToExec = ""
+    override val silence = ""
+    override val extension = ""
+  };
+
+  abstract val suffixLines: List<String>
+  abstract val howToExec: String
+  abstract val silence: String
+  abstract val extension: String
 }

--- a/src/nativeMain/kotlin/misc.kt
+++ b/src/nativeMain/kotlin/misc.kt
@@ -5,6 +5,7 @@ import com.github.ajalt.mordant.rendering.TextColors.green
 import com.github.ajalt.mordant.rendering.TextColors.yellow
 import com.github.ajalt.mordant.rendering.TextStyles.*
 import com.soywiz.klock.measureTime
+import com.soywiz.korio.file.VfsFile
 import kotlin.math.min
 import kotlin.system.exitProcess
 
@@ -54,3 +55,5 @@ class ColorHelpFormatter : CliktHelpFormatter(showDefaultValues = true) {
   override fun optionMetavar(option: HelpFormatter.ParameterHelp.Option) = green(super.optionMetavar(option))
 }
 
+val VfsFile.windowsPath: String
+  get() = this.absolutePath.replace("/mnt/c", "C:")


### PR DESCRIPTION
This also adds a specific for WSL2.

This option executes the operation on the windows host, if run with a
WSL2 Kernel.

There currently are multiple things hard-coded. The windows installation
needs to be in the C drive and it of course needs to be mounted inside
of WSL. WSL needs to have the windows interoperability that comes by
default to execute the cmd.exe.

This also reworks the way the command is built to be way cleaner and
easier to work with in the future